### PR TITLE
Fix parsing of answers that span more than one line

### DIFF
--- a/week_05_loading_data/quiz_parser.R
+++ b/week_05_loading_data/quiz_parser.R
@@ -9,7 +9,7 @@ parse_quiz_text <- function(quiz_text, NL="\n") quiz_text %>%
 	lapply(function(q){
 		lecture <- sub("^Lecture *(\\d[ab]).*", "\\1", q[1], ignore.case=T, perl=T)
 		question <- q[2]
-		answers <- strsplit(q[3],NL)[[1]] %>% sub("^[*] *", "", .)
+		answers <- strsplit(q[3],paste0(NL,'[*]'))[[1]] %>% sub("^[*] *", "", .)
 		list(lecture=lecture, question=question, answers=answers)
 	})
 


### PR DESCRIPTION
I hope you can pull this before you do the parsing, because one of my answers spans more than one line.

Example of an answer that spans more than one line: a matrix.
